### PR TITLE
feat: add tree-crasher implementation for Noir

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         # tree-crasher-{regex,solidity,sql} currently aren't suitable for upload to
         # crates.io because they have git dependencies
-        for pkg in tree-crasher{,-c,-css,-html,-javascript,-python,-rust,-typescript}; do
+        for pkg in tree-crasher{,-c,-css,-html,-javascript, -noir, -python,-rust,-typescript}; do
           if [[ ${PUSH} == true ]]; then
             cargo publish --token ${CRATES_IO_TOKEN} -p "${pkg}"
           else
@@ -101,7 +101,7 @@ jobs:
     - name: Build executables
       shell: bash
       run: |
-        for bin in ${NAME}-{c,css,javascript,regex,rust,solidity,sql,typescript}; do
+        for bin in ${NAME}-{c,css,javascript,noir,regex,rust,solidity,sql,typescript}; do
           cargo build \
             --bin ${bin} \
             --locked \
@@ -121,6 +121,7 @@ jobs:
           ${{ env.NAME }}-c_${{ matrix.target }},
           ${{ env.NAME }}-css_${{ matrix.target }},
           ${{ env.NAME }}-javascript_${{ matrix.target }},
+          ${{ env.NAME }}-noir_${{ matrix.target }},
           ${{ env.NAME }}-regex_${{ matrix.target }},
           ${{ env.NAME }}-rust_${{ matrix.target }},
           ${{ env.NAME }}-typescript_${{ matrix.target }},

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,6 +699,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-crasher-noir"
+version = "0.4.0"
+dependencies = [
+ "anyhow",
+ "tree-crasher",
+ "tree-sitter-noir",
+]
+
+[[package]]
 name = "tree-crasher-python"
 version = "0.4.0"
 dependencies = [
@@ -816,6 +825,16 @@ name = "tree-sitter-javascript"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2490fab08630b2c8943c320f7b63473cbf65511c8d83aec551beb9b4375906ed"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-noir"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09a0f7c33f9ea1e0ca3e3469e6660fac2c7d9539ea37e5cc1b22d98f91a374a"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/tree-crasher-css",
     "crates/tree-crasher-html",
     "crates/tree-crasher-javascript",
+    "crates/tree-crasher-noir",
     "crates/tree-crasher-python",
     "crates/tree-crasher-regex",
     "crates/tree-crasher-ruby",

--- a/crates/tree-crasher-noir/Cargo.toml
+++ b/crates/tree-crasher-noir/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "tree-crasher-noir"
+version = "0.4.0"
+edition = "2021"
+description = "Easy-to-use grammar-based black-box fuzzer"
+keywords = ["black-box", "fuzzer", "grammar-based"]
+authors = ["Langston Barrett <langston.barrett@gmail.com>"]
+license = "MIT"
+readme = "../../README.md"
+homepage = "https://github.com/langston-barrett/tree-crasher"
+repository = "https://github.com/langston-barrett/tree-crasher"
+
+[dependencies]
+anyhow = "1"
+tree-crasher = { version = "0.4.0", path = "../tree-crasher" }
+tree-sitter-noir = "0.0.1"

--- a/crates/tree-crasher-noir/src/main.rs
+++ b/crates/tree-crasher-noir/src/main.rs
@@ -1,0 +1,8 @@
+use anyhow::Result;
+
+fn main() -> Result<()> {
+    tree_crasher::main(
+        tree_sitter_noir::language(),
+        tree_sitter_noir::NODE_TYPES,
+    )
+}

--- a/scripts/corpora/noir.sh
+++ b/scripts/corpora/noir.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+repos=(
+    "noir-lang/noir"
+)
+mkdir -p noir-lang
+for repo in "${repos[@]}"; do
+  base=$(basename "${repo}")
+  echo $base
+  if ! [[ -d "${base}" ]]; then
+    git clone --jobs 4 --depth 1 "https://github.com/${repo}"
+  fi
+  for f in $(find "${base}" -type f -name "*.nr"); do
+    echo "${f}"
+    cp "${f}" noir-lang/"${base}-$(sha256sum "${f}" | head -c 5)-$(basename "${f}")"
+  done
+done


### PR DESCRIPTION
This PR :
- Adds support for [Noir lang](https://github.com/noir-lang/noir) by creating `tree-crasher-noir`.